### PR TITLE
Fix problem where marketing number and build number being read from the info.plist were flipped.

### DIFF
--- a/Sources/VersionCheck/AppVersionFetcher.swift
+++ b/Sources/VersionCheck/AppVersionFetcher.swift
@@ -14,6 +14,6 @@ public struct IOSVersionFetcher: AppVersionFetcher {
         //...
     }
 
-    public var marketing: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
-    public var build: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+    public var marketing: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+    public var build: String? { Bundle.main.infoDictionary?["CFBundleVersion"] as? String }
 }


### PR DESCRIPTION
Ugh. Such a dumb, terrible, bug.

Weird thing is: I'm pretty sure I just copied this code from another project, which means now I'm paranoid that we have some OTHER project out there that also has these inverted in them (I checked a couple of them that I had handy and they seemed fine)